### PR TITLE
Update the README.md Gitlab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ see `postprocess.sh` in this repository.
 
 # Developing
 
-Megapixels is developed at: https://gitlab.com/postmarketOS/megapixels
+Megapixels is developed at: https://gitlab.com/megapixels-org/Megapixels
 
 ## Source code organization
 


### PR DESCRIPTION
The old link lead to an archived Gitlab repo.